### PR TITLE
Add Facade reference to View

### DIFF
--- a/lib/core/Facade.ts
+++ b/lib/core/Facade.ts
@@ -19,6 +19,7 @@ export default class Facade{
     }
 
     public registerView(key:string, view:IView):void{
+        view.setFacade(this);
         this._views.set(key, view);
     }
 

--- a/lib/core/view/IView.ts
+++ b/lib/core/view/IView.ts
@@ -1,1 +1,6 @@
-export default interface IView{}
+import Facade from "../Facade";
+
+export default interface IView{
+    setFacade(facade:Facade):void; 
+    getFacade():Facade|null;
+}

--- a/lib/core/view/View.ts
+++ b/lib/core/view/View.ts
@@ -1,0 +1,13 @@
+import Facade from "../Facade";
+import IView from "./IView";
+
+export default class Model implements IView{
+    private _facade:Facade|null = null;
+
+    setFacade(facade: Facade): void {
+        this._facade = facade;
+    }
+    getFacade(): Facade {
+        return this._facade;
+    }
+}

--- a/test/core/Facade.spec.ts
+++ b/test/core/Facade.spec.ts
@@ -31,7 +31,7 @@ describe('Facade test suite',
     it('should be able to register view and retrieve it', 
     ()=>{
         // given 
-        const view = container.resolve(DEFAULT_VIEW);
+        const view:IView = container.resolve(DEFAULT_VIEW);
         facade.registerView(DEFAULT_VIEW, view);
 
         // when 
@@ -39,6 +39,19 @@ describe('Facade test suite',
 
         // then
         expect(result).toBe(view);
+    });
+
+    it('should set the facade of the registered view', 
+    ()=>{
+        // given 
+        const view:IView = container.resolve(DEFAULT_VIEW);
+        facade.registerView(DEFAULT_VIEW, view);
+
+        // when 
+        const result:IView = facade.getView(DEFAULT_VIEW);
+
+        // then
+        expect(result.getFacade()).toBe(facade);
     });
 
     it('should be able to register model and retrieve it', 
@@ -57,7 +70,7 @@ describe('Facade test suite',
     it('should set the facade of the registered model', 
     ()=>{
         // given 
-        const model = container.resolve(DEFAULT_MODEL);
+        const model:IModel = container.resolve(DEFAULT_MODEL);
         facade.registerModel(DEFAULT_MODEL, model);
 
         // when 

--- a/test/core/model/Model.spec.ts
+++ b/test/core/model/Model.spec.ts
@@ -16,5 +16,5 @@ describe('Model Test Suite',
     ()=>{     
         model.setFacade(facade);
         expect(model.getFacade()).toBe(facade);
-    })
+    });
 } )

--- a/test/core/model/StoreModel.spec.ts
+++ b/test/core/model/StoreModel.spec.ts
@@ -1,5 +1,5 @@
-import IStoreModel from "../../lib/core/model/IStoreModel";
-import { container, DEFAULT_STORE } from "../utils/config.spec";
+import IStoreModel from "../../../lib/core/model/IStoreModel";
+import { container, DEFAULT_STORE } from "../../utils/config.spec";
 
 describe('StoreModel test suite', 
 ()=>{

--- a/test/core/view/View.spec.ts
+++ b/test/core/view/View.spec.ts
@@ -1,0 +1,21 @@
+import Facade from "../../../lib/core/Facade";
+import IView from "../../../lib/core/view/IView";
+import { container, DEFAULT_FACADE, DEFAULT_VIEW } from "../../utils/config.spec";
+
+describe('View test suite', ()=>{
+    const view:IView = container.resolve(DEFAULT_VIEW);
+    const facade:Facade = container.resolve(DEFAULT_FACADE);
+
+    it('should be able to create a view', 
+    ()=>{
+        expect(view).toBeTruthy();
+    }); 
+
+    it('should be able to set/get Facade', 
+    ()=>{     
+        view.setFacade(facade);
+        expect(view.getFacade()).toBe(facade);
+    });
+
+    
+})

--- a/test/utils/config.spec.ts
+++ b/test/utils/config.spec.ts
@@ -2,8 +2,7 @@ import ICommand from "../../lib/core/command/ICommand";
 import Container from "../../lib/core/ioc/Container";
 import StoreModel from "../../lib/core/model/StoreModel";
 import IService from "../../lib/core/service/IService";
-import IView from "../../lib/core/view/IView";
-import IModel from "../../lib/core/model/IModel";
+import View from "../../lib/core/view/View";
 import Model from "../../lib/core/model/Model";
 import Facade from "../../lib/core/Facade";
 
@@ -18,7 +17,6 @@ class ChangeNameCommand implements ICommand{
     }
 }
 
-class MyView implements IView{}
 class MyService implements IService{}
 
 
@@ -31,7 +29,7 @@ export const DEFAULT_STORE = "MyStoreModel";
 export const DEFAULT_FACADE = "MyFacade";
 
 container.register(CHANGE_NAME_COMMAND, ()=>new ChangeNameCommand()); 
-container.register(DEFAULT_VIEW, ()=>new MyView());
+container.register(DEFAULT_VIEW, ()=>new View());
 container.register(DEFAULT_MODEL, ()=>new Model());
 container.register(DEFAULT_SERVICE, ()=>new MyService());
 container.register(DEFAULT_STORE, ()=>new StoreModel());


### PR DESCRIPTION
If we want to send notification to Facade from the view,
then we need a reference to the Facade. So one added :

A setFacade(facade:Facade) method to IModel
A getFacade():Facade method to IModel
A basic View class
When a view is registerd on a Facade, then we set that view's facade.