### PR TITLE
Add emitter to the lib and turn facade to emitter

### DIFF
--- a/lib/core/Facade.ts
+++ b/lib/core/Facade.ts
@@ -2,15 +2,20 @@ import { ICommandFactoryMethod } from "./command/ICommand";
 import IModel from "./model/IModel";
 import IView from "./view/IView";
 import IService from "./service/IService";
+import { Emitter, INotification } from "@thetinyspark/tiny-observer";
 
-export default class Facade{
-    private _commands:Map<string,ICommandFactoryMethod>     = new Map<string,ICommandFactoryMethod>();
+export default class Facade extends Emitter{
     private _models:Map<string,IModel>                      = new Map<string,IModel>();
     private _views:Map<string,IView>                        = new Map<string,IView>();
     private _services:Map<string,IService>                  = new Map<string,IService>();
 
     public registerCommand(key:string, factoryMethod:ICommandFactoryMethod):void{
-        this._commands.set(key, factoryMethod);
+        this.subscribe(
+            key, 
+            (notification:INotification)=>{
+                factoryMethod.call(null).execute(notification);
+            }
+        );
     }
 
     public registerModel(key:string, model:IModel):void{
@@ -39,10 +44,7 @@ export default class Facade{
         return this._views.get(key) || null;
     }
 
-    public notify(key:string, payload:any = null):void{
-        const method = this._commands.get(key) || null; 
-        if( method !== null){
-            return method.call(null).execute(payload);
-        }
+    public sendNotification = (key:string, payload:any = null):void =>{
+        this.emit(key, payload);
     }
 }

--- a/lib/core/command/ICommand.ts
+++ b/lib/core/command/ICommand.ts
@@ -1,5 +1,7 @@
+import { INotification } from "@thetinyspark/tiny-observer";
+
 export default interface ICommand{
-    execute(payload:any):void;
+    execute(notification:INotification):void;
 }
 
 export type ICommandFactoryMethod = (...args: any[]) => ICommand;

--- a/lib/core/model/Model.ts
+++ b/lib/core/model/Model.ts
@@ -7,6 +7,7 @@ export default class Model implements IModel{
     setFacade(facade: Facade): void {
         this._facade = facade;
     }
+
     getFacade(): Facade {
         return this._facade;
     }

--- a/lib/core/view/View.ts
+++ b/lib/core/view/View.ts
@@ -1,12 +1,13 @@
 import Facade from "../Facade";
 import IView from "./IView";
 
-export default class Model implements IView{
+export default class View implements IView{
     private _facade:Facade|null = null;
 
     setFacade(facade: Facade): void {
         this._facade = facade;
     }
+
     getFacade(): Facade {
         return this._facade;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "your-project-name",
-  "version": "0.0.1",
+  "version": "0.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -371,6 +371,11 @@
       "requires": {
         "defer-to-connect": "^1.0.1"
       }
+    },
+    "@thetinyspark/tiny-observer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@thetinyspark/tiny-observer/-/tiny-observer-1.0.1.tgz",
+      "integrity": "sha512-GRa0GiCjU0+gTqCwayhqKCVki45PyGvB+wDBTs0zgDi6RlRhFWxDTFAHvWMO3SvU5N7PO4PYtrKytfM7yZBIrg=="
     },
     "@types/component-emitter": {
       "version": "1.2.10",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
     "url": "https://github.com/thetinyspark/your-project-name/issues"
   },
   "homepage": "https://github.com/thetinyspark/your-project-name#readme",
-  "dependencies": {},
+  "dependencies": {
+    "@thetinyspark/tiny-observer": "^1.0.1"
+  },
   "devDependencies": {
     "@types/jasmine": "^3.8.1",
     "@types/node": "^16.4.5",

--- a/test/core/Facade.spec.ts
+++ b/test/core/Facade.spec.ts
@@ -22,7 +22,7 @@ describe('Facade test suite',
 
         // when 
         facade.registerCommand("CHANGE_NAME_COMMAND", method);
-        facade.notify("CHANGE_NAME_COMMAND", character);
+        facade.sendNotification("CHANGE_NAME_COMMAND", character);
 
         // then 
         expect(character.name).toEqual("Arthur");

--- a/test/core/model/Model.spec.ts
+++ b/test/core/model/Model.spec.ts
@@ -1,3 +1,4 @@
+import { INotification } from "@thetinyspark/tiny-observer";
 import Facade from "../../../lib/core/Facade";
 import IModel from "../../../lib/core/model/IModel";
 import { container, DEFAULT_FACADE, DEFAULT_MODEL } from "../../utils/config.spec"

--- a/test/core/view/View.spec.ts
+++ b/test/core/view/View.spec.ts
@@ -1,3 +1,4 @@
+import { INotification } from "@thetinyspark/tiny-observer";
 import Facade from "../../../lib/core/Facade";
 import IView from "../../../lib/core/view/IView";
 import { container, DEFAULT_FACADE, DEFAULT_VIEW } from "../../utils/config.spec";
@@ -16,6 +17,4 @@ describe('View test suite', ()=>{
         view.setFacade(facade);
         expect(view.getFacade()).toBe(facade);
     });
-
-    
 })

--- a/test/utils/config.spec.ts
+++ b/test/utils/config.spec.ts
@@ -5,15 +5,14 @@ import IService from "../../lib/core/service/IService";
 import View from "../../lib/core/view/View";
 import Model from "../../lib/core/model/Model";
 import Facade from "../../lib/core/Facade";
+import { INotification } from "@thetinyspark/tiny-observer";
 
 export const container = new Container(); 
 
-
-
 /** default classes */
 class ChangeNameCommand implements ICommand{
-    execute(character){
-        character.name = "Arthur";
+    execute(notification:INotification){
+        notification.getPayload().name = "Arthur";
     }
 }
 


### PR DESCRIPTION
We need a centralized way to dispatch / subscribe to event. 
We also need to listen to Facade event on Views and Models. 

Solution: 
- Add @thetinyspark/tiny-observer lib
- Turn Facade object into an Emitter by inheritance. 