### PR TITLE
Add Module support

### DIFF
--- a/lib/core/ioc/Container.ts
+++ b/lib/core/ioc/Container.ts
@@ -1,5 +1,4 @@
 export default class Container{
-
     private _map:Map<string,Function>;
     private _singleton:Map<string,any>;
 

--- a/lib/core/module/CoffeeModule.ts
+++ b/lib/core/module/CoffeeModule.ts
@@ -1,0 +1,43 @@
+import Facade from "../Facade";
+import ICoffeeModule, { ModuleConfiguration } from "./ICoffeeModule";
+
+export default class CoffeeModule implements ICoffeeModule{
+    private _config:ModuleConfiguration = null;
+
+    load(facade: Facade): void {
+        if( this._config === null )
+            return; 
+        
+        this._config.proxies.forEach( 
+            (value)=>{
+                facade.registerProxy(value.key, value.instance);
+            }
+        );
+
+        this._config.mediators.forEach( 
+            (value)=>{
+                facade.registerMediator(value.key, value.instance);
+            }
+        );
+
+        this._config.services.forEach( 
+            (value)=>{
+                facade.registerService(value.key, value.instance);
+            }
+        );
+
+        this._config.commands.forEach( 
+            (value)=>{
+                facade.registerCommand(value.key, value.factory);
+            }
+        );
+    }
+
+    getConfiguration(): ModuleConfiguration {
+        return this._config;
+    }
+
+    configure(config: ModuleConfiguration): void {
+        this._config = config;
+    }
+}

--- a/lib/core/module/ICoffeeModule.ts
+++ b/lib/core/module/ICoffeeModule.ts
@@ -1,0 +1,15 @@
+import { ICommandFactoryMethod, IMediator, IProxy, IService } from "../..";
+import Facade from "../Facade";
+
+export type ModuleConfiguration = {
+    commands: {key:string, factory:ICommandFactoryMethod}[], 
+    proxies:{key:string, instance:IProxy}[],
+    mediators:{key:string, instance:IMediator}[],
+    services:{key:string, instance:IService}[],
+};
+
+export default interface ICoffeeModule{
+    load(facade:Facade):void;
+    configure(config:ModuleConfiguration):void;
+    getConfiguration():ModuleConfiguration;
+}

--- a/test/core/Facade.spec.ts
+++ b/test/core/Facade.spec.ts
@@ -22,8 +22,8 @@ describe('Facade test suite',
         const method = container.get(CHANGE_NAME_COMMAND) as ICommandFactoryMethod; 
 
         // when 
-        facade.registerCommand("CHANGE_NAME_COMMAND", method);
-        facade.sendNotification("CHANGE_NAME_COMMAND", character);
+        facade.registerCommand(CHANGE_NAME_COMMAND, method);
+        facade.sendNotification(CHANGE_NAME_COMMAND, character);
 
         // then 
         expect(character.name).toEqual("Arthur");

--- a/test/core/module/Module.spec.ts
+++ b/test/core/module/Module.spec.ts
@@ -1,0 +1,131 @@
+import { Facade, ICommandFactoryMethod, IMediator, IProxy, IService } from "../../../lib";
+import CoffeeModule from "../../../lib/core/module/CoffeeModule";
+import { ModuleConfiguration } from "../../../lib/core/module/ICoffeeModule";
+import { CHANGE_NAME_COMMAND, container, DEFAULT_FACADE, DEFAULT_MEDIATOR, DEFAULT_PROXY, DEFAULT_SERVICE } from "../../utils/config.spec";
+
+describe('Model Test Suite', 
+()=>{
+
+    const commandFactory:ICommandFactoryMethod = container.get(CHANGE_NAME_COMMAND) as ICommandFactoryMethod;
+    const proxy:IProxy = container.resolve(DEFAULT_PROXY) as IProxy;
+    const service:IService = container.resolve(DEFAULT_SERVICE) as IService;
+    const mediator:IMediator = container.resolve(DEFAULT_MEDIATOR) as IMediator;
+
+
+    it('should be able to create a module instance', 
+    ()=>{
+        const myModule = new CoffeeModule()
+        expect(myModule).toBeTruthy();
+    }); 
+
+    it('should have a null configuration by default', 
+    ()=>{
+        // given
+        const myModule = new CoffeeModule()
+        // then 
+        expect( myModule.getConfiguration() ).toBeNull();
+    });
+
+    it('should be able to set and get configuration', 
+    ()=>{
+        // given
+        const myModule = new CoffeeModule()
+        const configuration:ModuleConfiguration = {
+            commands: [], 
+            proxies:[], 
+            services:[], 
+            mediators:[{key:DEFAULT_MEDIATOR, instance: mediator}]
+        } as ModuleConfiguration;
+
+        // when 
+        myModule.configure(configuration); 
+
+        // then 
+        expect( myModule.getConfiguration() ).toBe(configuration);
+    })
+
+    it('should be able to configure a module and retrieve mediator', 
+    ()=>{
+        // given
+        const facade:Facade = container.resolve(DEFAULT_FACADE);
+        const myModule = new CoffeeModule();
+        const configuration:ModuleConfiguration = {
+            commands: [], 
+            proxies:[], 
+            services:[], 
+            mediators:[{key:DEFAULT_MEDIATOR, instance: mediator}]
+        } as ModuleConfiguration;
+
+        // when
+
+        myModule.configure(configuration);
+        myModule.load(facade);
+
+        // then
+        expect(facade.getMediator(DEFAULT_MEDIATOR)).toBe(mediator);
+    });
+
+    it('should be able to configure a module and retrieve service', 
+    ()=>{
+        // given
+        const facade:Facade = container.resolve(DEFAULT_FACADE);
+        const myModule = new CoffeeModule();
+        const configuration:ModuleConfiguration = {
+            commands: [], 
+            proxies:[], 
+            services:[{key:DEFAULT_SERVICE, instance: service}], 
+            mediators:[]
+        } as ModuleConfiguration;
+
+        // when
+
+        myModule.configure(configuration);
+        myModule.load(facade);
+
+        // then
+        expect(facade.getService(DEFAULT_SERVICE)).toBe(service);
+    });
+
+    it('should be able to configure a module and retrieve proxy', 
+    ()=>{
+        // given
+        const facade:Facade = container.resolve(DEFAULT_FACADE);
+        const myModule = new CoffeeModule();
+        const configuration:ModuleConfiguration = {
+            commands: [], 
+            proxies:[{key:DEFAULT_PROXY, instance: proxy}], 
+            services:[], 
+            mediators:[]
+        } as ModuleConfiguration;
+
+        // when
+
+        myModule.configure(configuration);
+        myModule.load(facade);
+
+        // then
+        expect(facade.getProxy(DEFAULT_PROXY)).toBe(proxy);
+    });
+
+    it('should be able to configure a module and execute command factory', 
+    ()=>{
+        // given
+        const facade:Facade = container.resolve(DEFAULT_FACADE);
+        const myModule = new CoffeeModule();
+        const character = {name:"Merlin"}; 
+        const configuration:ModuleConfiguration = {
+            commands: [{key:CHANGE_NAME_COMMAND, factory: commandFactory}], 
+            proxies:[], 
+            services:[], 
+            mediators:[]
+        } as ModuleConfiguration;
+
+        // when
+        myModule.configure(configuration);
+        myModule.load(facade);
+        facade.sendNotification(CHANGE_NAME_COMMAND, character);
+
+        // then
+        expect(character.name).toEqual("Arthur");
+    });
+} )

--- a/test/utils/config.spec.ts
+++ b/test/utils/config.spec.ts
@@ -1,5 +1,5 @@
 import ICommand from "../../lib/core/command/ICommand";
-import Container, { rootContainer } from "../../lib/core/ioc/Container";
+import Container from "../../lib/core/ioc/Container";
 import StoreModel from "../../lib/core/model/StoreModel";
 import IService from "../../lib/core/service/IService";
 import Mediator from "../../lib/core/view/Mediator";


### PR DESCRIPTION
Sometimes, we need to package related commands, services, proxies and mediators together. 
We also need to be able to load them on a dedicated facade. 
Then, we're adding module packaging. 